### PR TITLE
Fix ckiller issues with everything being Pan lords.

### DIFF
--- a/sqllog.pl
+++ b/sqllog.pl
@@ -88,7 +88,7 @@ my @UNIQUES = ("Ijyb", "Blork the orc", "Blork", "Urug", "Erolcha", "Snorg",
   "Eustachio", "Nessos", "Dowan", "Duvessa", "Grum", "Crazy Yiuf",
   "Gastronok", "Pikel", "Menkaure", "Khufu", "Aizul", "Purgy",
   "Kirke", "Maurice", "Nikola", "Mara", "Grinder", "Mennas", "Chuck",
-  "the iron giant", "Nellie");
+  "the iron giant", "Nellie", "Wiglaf", "Jory", "Terpsichore", "Ignacio");
 
 my $TLOGFILE   = 'logrecord';
 my $TMILESTONE = 'milestone';
@@ -609,18 +609,33 @@ sub fixup_logfields {
     $g->{ckiller} = $g->{killer} || $g->{ktyp} || '';
     for ($g->{ckiller}) {
       s/^an? \w+-headed (hydra.*)$/a $1/;
+      s/^the \w+-headed ((?:Lernaean )?hydra.*)$/the $1/;
       s/^.*'s? ghost$/a player ghost/;
       s/^.*'s? illusion$/a player illusion/;
       s/^an? \w+ (draconian.*)/a $1/;
+      s/^an? .* \(((?:glowing )?shapeshifter)\)$/a $1/;
+      s/^the .* shaped (.*)$/the $1/;
 
-      # If it's an actual kill, merge Pan lords.
+      # If it's an actual kill, merge Pan lords together, polyed uniques with
+      # their normal counterparts, and named orcs with their monster type.
       my $kill = $g->{killer};
       if ($kill && $kill =~ /^[A-Z]/) {
-        my ($name) = /^([^,]*)/;
-        $_ = 'a pandemonium lord'
-          if !/^(?:an?|the) / && !$UNIQUES{$name} && !/,/;
-        # Fix Blork and variants thereof.
-        $_ = 'Blork' if /^Blork/;
+        my ($name) = /^([A-Z]\w*(?: [A-Z]\w*)*)/;
+        if ($kill =~ / the /) {
+          my ($mons) = / the (.*)$/;
+          # Also takes care of Blork variants.
+          if ($UNIQUES{$name}) {
+            $_ = $name;
+          } else {
+            # Usually these will all be orcs.
+            $mons = 'a ' . $mons;
+            $mons =~ s/^a ([aeiou].*)$/an $1/;
+            $_ = $mons;
+          }
+        } else {
+          $_ = 'a pandemonium lord'
+            if !/^(?:an?|the) / && !$UNIQUES{$name};
+        }
       }
     }
 


### PR DESCRIPTION
This change alters the initial death entry so that ckiller is set to something appropriate in some special cases not previously handled (or handled wrong once deaths became attributed to "Sigmund the orange rat" instead of "Sigmund, the orange rat"). This won't change any previous deaths stored in the database (if only it were that easy).
- Add new uniques to the list of recognized uniques.
- All polymorphed uniques get ckiller set to their name (not just Blork).
- Named orcs get ckiller set to their monster class
- The Lernaean hydra headcount is removed from ckiller.
- Shapeshifters get ckiller set to 'a shapeshifter' or 'a glowing shapeshifter'.

(Actually, the lines for Blork didn't work before, either.)

<pre>
Zannick: !lg athamar killer=blork the centaur x=ckiller 1
Sequell: 1. [ckiller=a pandemonium lord] athamar the Ruffian (L4 TrWz),
         slain by Blork the centaur (a +0,+0 orcish scimitar) on D:4
         on 2011-08-19, with 248 points after 2928 turns and 0:23:24.
</pre>


Some examples:

<pre>
  killer                                   |   ckiller
Sigmund, the orange rat                    | Old: Sigmund, the orange rat
Sigmund, the orange rat                    | New: Sigmund
Sigmund the orange rat                     | Old: a pandemonium lord
Sigmund the orange rat                     | New: Sigmund
Biutav                                     | Old: a pandemonium lord
Biutav                                     | New: a pandemonium lord
Boric the orc knight                       | Old: a pandemonium lord
Boric the orc knight                       | New: an orc knight
Blork the centaur                          | Old: a pandemonium lord
Blork the centaur                          | New: Blork
Wiglaf                                     | Old: a pandemonium lord
Wiglaf                                     | New: Wiglaf
Prince Ribbit the dragon                   | Old: a pandemonium lord
Prince Ribbit the dragon                   | New: Prince Ribbit
the elephant slug shaped Royal Jelly       | Old: the elephant slug shaped Royal Jelly
the elephant slug shaped Royal Jelly       | New: the Royal Jelly
the yaktaur shaped Lernaean hydra          | Old: the yaktaur shaped Lernaean hydra
the yaktaur shaped Lernaean hydra          | New: the Lernaean hydra
a killer bee shaped shifter (shapeshifter) | Old: a killer bee shaped shifter (shapeshifter)
a killer bee shaped shifter (shapeshifter) | New: a shapeshifter
a dragon (glowing shapeshifter)            | Old: a dragon (glowing shapeshifter)
a dragon (glowing shapeshifter)            | New: a glowing shapeshifter
the 27-headed Lernaean hydra               | Old: the 27-headed Lernaean hydra
the 27-headed Lernaean hydra               | New: the Lernaean hydra
the nine-headed hydra shaped Royal Jelly   | Old: the nine-headed hydra shaped Royal Jelly
the nine-headed hydra shaped Royal Jelly   | New: the Royal Jelly
</pre>
