### PR TITLE
Fix foo[2] and redirect anchors in learndb.html

### DIFF
--- a/learndb-html.pl
+++ b/learndb-html.pl
@@ -45,7 +45,9 @@ for(split /\n/, `find dat/learndb/ -type f ! -name '*.html*'`)
         my $val = <F>;
         if ($val =~ $FULL_REDIRECT_PATTERN)
         {
-            addlink($key, $1);
+            my $dest = $1;
+            $dest =~ s/\[1\]$//;
+            addlink($key, $dest);
         }
         else
         {
@@ -111,7 +113,7 @@ for my $key (sort keys %learndb)
     next if !$has_multiple && $learndb{$key} =~ $FULL_REDIRECT_PATTERN;
 
     print "<dt>";
-    print   "<a name=\"$key\"></a>" for(sort keys %{$redir{$key}});
+    print   "<a name=\"$_\"></a>" for(sort keys %{$redir{$key}});
 
     (my $clean_key = $key) =~ tr{_}{ };
     print "$clean_key\n";
@@ -124,7 +126,7 @@ for my $key (sort keys %learndb)
     {
       my $text = $learndb{$key."[$i]"};
       my $prefix = '';
-      $prefix .= "<a name=\"$key\"></a>" for(sort keys %{$redir{$key."[$i]"}});
+      $prefix .= "<a name=\"$_\"></a>" for(sort keys %{$redir{$key."[$i]"}});
       print htmlize($text, $has_multiple, $prefix), "\n";
     }
     print "</ol>" if $has_multiple;


### PR DESCRIPTION
A bug prevented the anchors for foo[2], foo[3], etc. from being
generated; instead, each had its own "foo" anchor.  Likewise, redirect
entries were supposed to get anchors at the destination, but these were
also being replaced with the destination's anchor.

Also, strip [1] from redirect targets, so that their anchors are
properly placed.
