### PR TITLE
Some new milestone types.

### DIFF
--- a/commands/crawl-data.yml
+++ b/commands/crawl-data.yml
@@ -461,6 +461,7 @@ milestone-types:
   - uniq.ens
   - br.enter
   - br.end
+  - br.mid
   - god.mollify
   - god.renounce
   - god.worship

--- a/henzell.pl
+++ b/henzell.pl
@@ -145,7 +145,7 @@ sub newsworthy
   my $br_enter = $type eq 'enter' || $type eq 'br.enter';
   my $place_branch = game_place_branch($g);
 
-  return 0 if grep($type eq $_, 'monstrous', 'death');
+  return 0 if grep($type eq $_, 'monstrous', 'death', 'br.mid');
 
   return 0
     if $br_enter

--- a/sqllog.pl
+++ b/sqllog.pl
@@ -738,7 +738,7 @@ sub milestone_mangle {
     my ($cause) = $noun =~ /.*\((.*?)\)$/;
     $noun = $cause ? $cause : '?';
   }
-  elsif ($verb eq 'br.enter' || $verb eq 'br.end') {
+  elsif ($verb eq 'br.enter' || $verb eq 'br.end' || $verb eq 'br.mid') {
     $noun = $g->{place};
     $noun =~ s/:.*//;
   }


### PR DESCRIPTION
I have DCSS commits ready to push that will start producing the following new milestone types:

uniq.pac/ghost.pac: pacified a unique/ghost (with Elyvilon, replacing the uniq milestone you used to get when the pacified monster left the level)
uniq.ens: enslaved the soul of a unique (with Yredelemnul; previously this didn't produce a milestone at all)
br.mid: entered D:14 for the first time (to simulate the rune lock as a trackable conduct)

The br.mid milestone has been added to the list of milestones that shouldn't be announced, so I'd appreciate it if you could update Henzell as well as Sequell if possible when you get a chance to look at this.

Thanks!
--elliptic
