### PR TITLE
Point Sequell at CDO 0.11 files.

### DIFF
--- a/def.logs
+++ b/def.logs
@@ -132,6 +132,14 @@ remote.cdo-logfile-0.10-sprint
 [remote:cdo:http://$cdo/allgames-zd-0.10.txt]
 remote.cdo-logfile-0.10-zd
 
+[remote:cdo:http://$cdo/allgames-0.11.txt]
+remote.cdo-logfile-0.11
+
+[remote:cdo:http://$cdo/allgames-spr-0.11.txt]
+remote.cdo-logfile-0.11-sprint
+
+[remote:cdo:http://$cdo/allgames-zd-0.11.txt]
+remote.cdo-logfile-0.11-zd
 
 [remote:cdo:http://$cdo/allgames-spr-svn.txt]
 remote.cdo-logfile-spr

--- a/def.stones
+++ b/def.stones
@@ -140,6 +140,14 @@ remote.cdo-milestones-0.10-sprint
 [remote:cdo:http://$cdo/milestones-zd-0.10.txt]
 remote.cdo-milestones-0.10-zd
 
+[remote:cdo:http://$cdo/milestones-0.11.txt]
+remote.cdo-milestones-0.11
+
+[remote:cdo:http://$cdo/milestones-spr-0.11.txt]
+remote.cdo-milestones-0.11-sprint
+
+[remote:cdo:http://$cdo/milestones-zd-0.11.txt]
+remote.cdo-milestones-0.11-zd
 
 [remote:cdo:http://$cdo/milestones-spr-svn.txt]
 remote.cdo-milestones-spr

--- a/servers.yml
+++ b/servers.yml
@@ -14,6 +14,7 @@ morgue-paths:
   - [ 'cdo.*-0.7', 'http://crawl.develz.org/morgues/0.7' ]
   - [ 'cdo.*-0.8', 'http://crawl.develz.org/morgues/0.8' ]
   - [ 'cdo.*-0.10', 'http://crawl.develz.org/morgues/0.10' ]
+  - [ 'cdo.*-0.11', 'http://crawl.develz.org/morgues/0.11' ]
   - [ 'cdo.*-svn$', 'http://crawl.develz.org/morgues/trunk' ]
   - [ 'cdo.*-zd$',  'http://crawl.develz.org/morgues/trunk' ]
   - [ 'cdo.*-spr$', 'http://crawl.develz.org/morgues/trunk' ]


### PR DESCRIPTION
CDO recently put up 0.11 (prerelease), so here's the standard update to point Sequell at it.

Also, I noticed that Sequell doesn't seem to be updating with new games/milestones from CSN (crawlus.somatika.net) even though the paths in the repository still seem to work... any idea what is going on there?

--elliptic
