### PR TITLE
Fix incorrect prepositions.

### DIFF
--- a/game_parser.pl
+++ b/game_parser.pl
@@ -151,7 +151,6 @@ sub game_place($) {
   }
 
   my $prep = $place =~ /:/? 'on' : 'in';
-  $prep = "in" if $g->{ltyp} ne 'D';
   $place = "the $place" if grep($_ eq $place, qw/Temple Abyss/);
   $place = "a Labyrinth" if $place eq 'Lab';
   $place = "a Bazaar" if $place eq 'Bzr';


### PR DESCRIPTION
The ltyp field was dropped in portal_branches (and thus in 0.11+), and this
meant that Sequell was always using "in", for instance "in D:3".

As far as I can tell, the ltyp field was only being used to make it say
"in Zig:14" rather than "on Zig:14" (see !lg \* place=~: ltyp!=D cv=0.10 s=place),
and the latter seems arguably more correct anyway.
