### PR TITLE
Fix deaths in Spider:1-5 being hidden in `!lg spider` queries

### DIFF
--- a/commands/crawl-data.yml
+++ b/commands/crawl-data.yml
@@ -273,6 +273,7 @@ branches:
   - 'Shoals:'
   - 'Slime:'
   - 'Snake:'
+  - 'Spider:'
   - 'Hive:'
   - 'Vault:'
   - 'Vaults:'
@@ -288,7 +289,6 @@ branches:
   - Lab
   - Pan
   - Bazaar
-  - Spider
   - Bzr
   - Hell
   - Blade


### PR DESCRIPTION
`!lg * spider` only found the Spider portal vault deads ("slain by it in Spider") and did ignore anything in Spider:1 to Spider:5. Not sure whether this fix will put the portal vault deaths on Spider:1 or something else but it's certainly better than entirely ignoring them.

Spider was listed as one-level deep portal vault, which it is not any longer.
