### PR TITLE
Fix game_ttyrec_datetime to use correct morgue_time.

### DIFF
--- a/src/henzell/ttyrec_search.rb
+++ b/src/henzell/ttyrec_search.rb
@@ -95,7 +95,7 @@ module Henzell
     end
 
     def game_ttyrec_datetime(game, key=nil)
-      time = morgue_time(game, key)
+      time = ::morgue_time(game, key)
       return nil if time.nil?
       dt = DateTime.strptime(time + "+0000", MORGUE_DATEFORMAT + '%z')
       if self.utc_epoch && dt < self.utc_epoch


### PR DESCRIPTION
As it stood Henzell::TtyrecSearch::ttyrecs_for couldn't be used because of this bug in game_ttyrec_datetime but once fixed it works a treat!

I guess all the methods in src/helper.rb want refactoring at some point but I figured it simplest to leave it as is for the time being.

Cheers,
Dan aka broquaint
