### PR TITLE
don't recognize ghosts as pan lords

### DIFF
--- a/lib/Henzell/Crawl.pm
+++ b/lib/Henzell/Crawl.pm
@@ -160,9 +160,14 @@ sub known_orc {
   $ORCS{$name}
 }
 
+sub player_ghost {
+  my $name = shift;
+  $name =~ /'s? ghost$/
+}
+
 sub possible_pan_lord {
   my $name = shift;
-  !/^(?:an?|the) / && !crawl_unique($name) && !known_orc($name)
+  !/^(?:an?|the) / && !crawl_unique($name) && !known_orc($name) && !player_ghost($name)
 }
 
 sub canonical_god_name {


### PR DESCRIPTION
This was happening when the ghost was of a player whose name was capitalized.

This isn't tested, since I don't have a Sequell installation, but looks reasonable enough.
