### PR TITLE
Add a space in FooTV description message.

### DIFF
--- a/src/libtv.rb
+++ b/src/libtv.rb
@@ -204,7 +204,7 @@ module TV
   end
 
   def self.tv_description(tv)
-    "#{tv} (#{TermcastConfig.client_urls.join(' or ')})"
+    "#{tv} (#{TermcastConfig.client_urls.join(' or ')} )"
   end
 
   def self.request_game_verbosely(n, g, who, tv_opt)


### PR DESCRIPTION
"http://termcast.develz.org)" is interpreted as a URL by some (dumb) IRC clients.
