### PR TITLE
Added god.ecumenical milestone

### DIFF
--- a/config/crawl-data.yml
+++ b/config/crawl-data.yml
@@ -1046,6 +1046,7 @@ milestone-types:
   - god.mollify
   - god.renounce
   - god.worship
+  - god.ecumenical
   - god.maxpiety
   - shaft
   - crash


### PR DESCRIPTION
It's a new milestone that is like `god.worship` except that verb=god.ecumenical. I think this change is enough to get Sequell to let you do searches like `!lm * recent god.ecumenical s=god`.