### PR TITLE
Eschew verbosity slightly less.

### DIFF
--- a/commands/message/tell.pl
+++ b/commands/message/tell.pl
@@ -33,7 +33,9 @@ $message = $2;
 
 if (length $message > 300)
 {
-  print "Maximum message length is 300 characters. Eschew verbosity, Gladys!\n";
+  printf "Maximum message length is 300 characters, but you had %d. ",
+         length $message;
+  print "Eschew verbosity, Gladys!\n";
   exit;
 }
 


### PR DESCRIPTION
Tell people how long their too-long message was, so they can estimate how
much they need to trim.