### PR TITLE
Add support for end-of-line comments to !lg

### DIFF
--- a/src/grammar/query.rb
+++ b/src/grammar/query.rb
@@ -14,7 +14,7 @@ module Grammar
          (space >> nicked_query_body).maybe.as(:head) >>
         (space? >> query_tail).maybe.as(:tail) >>
         (space? >> query_result_filter).maybe.as(:filter) >>
-        space?).as(:query)
+        space? >> comment.maybe).as(:query)
     }
 
     rule(:query_context) {
@@ -38,5 +38,6 @@ module Grammar
 
     rule(:space) { match('\s').repeat(1) }
     rule(:space?) { space.maybe }
+    rule(:comment) { str("--") >> match(".*")}
   end
 end


### PR DESCRIPTION
It'd be nice to be able to write like 

    !lm * recent won nrune=3 lg:nrune=3 s=rune -- which runes are taken last in a 3-rune game

to explain the context of a nonobvious query. Currently if I want to run a query and tell someone (or the room) about it, the only way to explain it is to send a separate irc message, which is a little tacky.

I don't actually have an instance of sequell, and gave up on installing all of the necessary dependencies, so I haven't run this through the tests.