### PR TITLE
Fix "La Petite Mort."

### DIFF
--- a/lib/Henzell/Game.pm
+++ b/lib/Henzell/Game.pm
@@ -67,7 +67,8 @@ sub game_skill_title
   my $game_ref = shift;
   my $title = $game_ref->{title};
   $title = skill_farming($title) if $game_ref->{turn} > 200000;
-  $title = "the $title" unless $title =~ /^(the|le|la|l')\b/i;
+  my $article = "La" if $title =~ /petite/i else "the";
+  $title = $article .  " " . $title unless $title =~ /^(the|le|la|l')\b/i;
   return $title;
 }
 


### PR DESCRIPTION
As of around a year back Crawl no longer saves the "La" in the player title itself.