### PR TITLE
add adrenaline_rush/desperate_haste logs/stones

### DIFF
--- a/config/sources.yml
+++ b/config/sources.yml
@@ -168,6 +168,7 @@ sources:
       - meta/abyssrun/{logfile,milestones}*: abyssrun
       - meta/orcs_and_elves/{logfile,milestones}*: orcs-and-elves
       - meta/combo_god/{logfile,milestones}*: combo-god
+      - meta/adrenaline_rush/{logfile,milestones}*: adrenaline-rush
     morgues:
       - http://crawl.berotato.org/crawl/morgue
     ttyrecs:


### PR DESCRIPTION
not sure if I set this up right since I think Lasty prefers the name 'desperate haste' instead of the branch name 'adrenaline_rush'. 

left it as it is since it follows previous naming conventions.

