### PR TITLE
Update sources.yml

### DIFF
--- a/config/sources.yml
+++ b/config/sources.yml
@@ -211,10 +211,10 @@ sources:
       - https://crawl.project357.org/ttyrec
 
   - name: cjr
-    base: https://crawl.jorgrun.rocks/meta
+    base: http://crawl.jorgrun.rocks/meta
     logs:
       - '{0.17,0.18,0.19,0.20,git}/{milestones,logfile}{,-sprint,-zotdef}*'
     morgues:
-      - https://crawl.jorgrun.rocks/morgue
+      - http://crawl.jorgrun.rocks/morgue
     ttyrecs:
-      - https://crawl.jorgrun.rocks/ttyrec
+      - http://crawl.jorgrun.rocks/ttyrec


### PR DESCRIPTION
CJR's SSL Certificate has been busted for days and it's preventing Sequell from working properly.  Let's just use the http instead, which works just fine.