### PR TITLE
Activate 2023 0.30 tournament

### DIFF
--- a/config/crawl-data.yml
+++ b/config/crawl-data.yml
@@ -1194,7 +1194,7 @@ tournament-prefixes:
   - tournament
 
 tournament-data:
-  default-tourney: '2022b'
+  default-tourney: '2023a'
   crawl:
     '2008':
       version: "0.4"


### PR DESCRIPTION
Mark the 2023 0.30 tournament as the default for the `t` keyword